### PR TITLE
fix: Photon generates a random nickname if none is provided

### DIFF
--- a/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
+++ b/Transports/com.mlapi.contrib.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
@@ -141,7 +141,7 @@ namespace MLAPI.Transports.PhotonRealtime
             if (m_Client == null)
             {
                 // This is taken from a Photon Realtime sample to get a random user name if none is provided.
-                var nickName = string.IsNullOrEmpty(m_NickName) ? m_NickName : "usr" + SupportClass.ThreadSafeRandom.Next() % 99;
+                var nickName = string.IsNullOrEmpty(m_NickName) ? "usr" + SupportClass.ThreadSafeRandom.Next() % 99 : m_NickName;
 
                 m_Client = new LoadBalancingClient
                 {


### PR DESCRIPTION
Seems there was a simple mistake made where it would only generate a random username if there was a nickname given, rather than the other way round.