### PR TITLE
Suggest new transform parent on instantiation

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkObjectPool/NetworkObjectPool.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkObjectPool/NetworkObjectPool.cs
@@ -109,7 +109,7 @@ namespace Netcode.Extensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private GameObject CreateInstance(GameObject prefab)
         {
-            return Instantiate(prefab);
+            return Instantiate(prefab, transform);
         }
 
         /// <summary>


### PR DESCRIPTION
Would leave hierarchy view much cleaner and organized in my scene view to attach the instantiated prefabs to the transform of the networkobject pool