### PR TITLE
Facepunch Transport fix

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -211,7 +211,7 @@ namespace Netcode.Transports.Facepunch
         {
             byte[] payload = new byte[size];
             Marshal.Copy(data, payload, 0, size);
-            InvokeOnTransportEvent(NetworkEvent.Data, ServerClientId, new ArraySegment<byte>(payload, 0, size - 1), Time.realtimeSinceStartup);
+            InvokeOnTransportEvent(NetworkEvent.Data, ServerClientId, new ArraySegment<byte>(payload, 0, size), Time.realtimeSinceStartup);
         }
 
         #endregion

--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -134,20 +134,16 @@ namespace Netcode.Transports.Facepunch
             }
         }
 
-        public override unsafe void Send(ulong clientId, ArraySegment<byte> data, NetworkDelivery delivery)
+        public override void Send(ulong clientId, ArraySegment<byte> data, NetworkDelivery delivery)
         {
-            var sendType = NetworkDeliveryToSendType(delivery);
+	        var sendType = NetworkDeliveryToSendType(delivery);
 
-            byte* buffer = stackalloc byte[data.Count];
-            fixed (byte* pointer = data.Array)
-                Buffer.MemoryCopy(pointer + data.Offset, buffer, data.Count, data.Count);
-
-            if (clientId == ServerClientId)
-                connectionManager.Connection.SendMessage((IntPtr)buffer, data.Count , sendType);
-            else if (connectedClients.TryGetValue(clientId, out Client user))
-                user.connection.SendMessage((IntPtr)buffer, data.Count, sendType);
-            else if (LogLevel <= LogLevel.Normal)
-                Debug.LogWarning($"[{nameof(FacepunchTransport)}] - Failed to send packet to remote client with ID {clientId}, client not connected.");
+	        if (clientId == ServerClientId)
+		        connectionManager.Connection.SendMessage(data.Array, data.Offset, data.Count, sendType);
+	        else if (connectedClients.TryGetValue(clientId, out Client user))
+		        user.connection.SendMessage(data.Array, data.Offset, data.Count, sendType);
+	        else if (LogLevel <= LogLevel.Normal)
+		        Debug.LogWarning($"[{nameof(FacepunchTransport)}] - Failed to send packet to remote client with ID {clientId}, client not connected.");
         }
 
         public override NetworkEvent PollEvent(out ulong clientId, out ArraySegment<byte> payload, out float receiveTime)


### PR DESCRIPTION
IConnectionManager.OnMessage created a byte array segment 1 byte too short, which caused clients to not load in, along with the warning:
`[Netcode] Received a message that claimed a size larger than the packet, ending early!`
This is most likely a remnant from having to remove the networkChannel byte from the packet in the previous 0.1.0 release of MLAPI.

Additionally, the Transport.Send override had an 'unsafe' buffer copy (again, most likely from having to add the networkChannel byte in a previous release), which is no longer necessary when using a different SendMessage overload from Facepunch's networking solution.