### PR TITLE
fix(1.0.0-pre.3): Photon Transport connect event id assignment

### DIFF
--- a/Transports/com.community.netcode.transport.photon-realtime/Runtime/PhotonRealtimeTransport.Matchmaking.cs
+++ b/Transports/com.community.netcode.transport.photon-realtime/Runtime/PhotonRealtimeTransport.Matchmaking.cs
@@ -38,10 +38,8 @@ namespace Netcode.Transports.PhotonRealtime
             // any client (except host/server) need to know about their own join event
             if (!m_IsHostOrServer)
             {
-                var senderId = GetMlapiClientId(m_Client.LocalPlayer.ActorNumber, false);
-
                 NetworkEvent netEvent = NetworkEvent.Connect;
-                InvokeTransportEvent(netEvent, senderId);
+                InvokeTransportEvent(netEvent, GetMlapiClientId(m_originalRoomMasterClient, false));
             }
         }
 
@@ -60,10 +58,8 @@ namespace Netcode.Transports.PhotonRealtime
             // any client (except host/server) need to know about their own leave event
             if (!this.m_IsHostOrServer)
             {
-                var senderId = GetMlapiClientId(m_Client.LocalPlayer.ActorNumber, false);
-
                 NetworkEvent netEvent = NetworkEvent.Connect;
-                InvokeTransportEvent(netEvent, senderId);
+                InvokeTransportEvent(netEvent, GetMlapiClientId(m_originalRoomMasterClient, false));
             }
         }
     }

--- a/Transports/com.community.netcode.transport.photon-realtime/Runtime/PhotonRealtimeTransport.Room.cs
+++ b/Transports/com.community.netcode.transport.photon-realtime/Runtime/PhotonRealtimeTransport.Room.cs
@@ -37,13 +37,18 @@ namespace Netcode.Transports.PhotonRealtime
             // server/host gets any player's leave. 
             // all clients disconnect when the server/host leaves.
 
-            if (m_IsHostOrServer || otherPlayer.ActorNumber == m_originalRoomMasterClient)
+            if (m_IsHostOrServer)
             {
                 var senderId = GetMlapiClientId(otherPlayer.ActorNumber, false);
                 //Debug.Log("Host got OnPlayerLeftRoom() with senderId: "+senderId);
                 
                 NetworkEvent netEvent = NetworkEvent.Disconnect;
                 InvokeTransportEvent(netEvent, senderId);
+            }
+            else if (otherPlayer.ActorNumber == m_originalRoomMasterClient)
+            {
+                NetworkEvent netEvent = NetworkEvent.Disconnect;
+                InvokeTransportEvent(netEvent, GetMlapiClientId(m_originalRoomMasterClient, false));
             }
         }
 


### PR DESCRIPTION
Connect event ids on the client now contain the hosts peer id instead of the clients own id. This results in the Photon Realtime transport behaving similar to the UNet and UnityTransport and allows it to work with [#1368](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1368)

Tested on Boss Room `fix/ngo-pre.3` branch (#483194dd749e062fcedd58d3fac43caeb0d7587b) with 1 host + 2 clients on same machine able to connect to the lobby select a character and walk around in the game using Photon Realtime Transport