### PR TITLE
fix: extension package dependencies

### DIFF
--- a/com.community.netcode.extensions/package.json
+++ b/com.community.netcode.extensions/package.json
@@ -6,7 +6,7 @@
   "description": "The Netcode for GameObjects Community Extensions package is a package containing extensions to Netcode for GameObjects.",
   "author": "",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "0.2.0-preview.1",
-    "com.unity.netcode.adapter.utp" : "0.1.0-preview.1"
+    "com.unity.netcode.gameobjects": "1.0.0-pre.3",
+    "com.unity.netcode.adapter.utp" : "1.0.0-pre.3"
   }
 }


### PR DESCRIPTION
The extension package had invalid (non existing) dependencies which caused errors when installing the package while the UTP adapter package was not installed already.