### PR TITLE
fix: Add fixedqueue back

### DIFF
--- a/com.community.netcode.extensions/CHANGELOG.md
+++ b/com.community.netcode.extensions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 All notable changes to this package will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## 1.0.1
+
+### Fixed
+
+- Added FixedQueue class which was removed in the 1.0.0-pre4 version and was used by LagCompensation into the extensions package.
+
+### Changed
+
+- Updated com.unity.netcode.gameobjects dependency to 1.0.0-pre4
+- Update com.unity.netcode.adapter.utp dependency to 1.0.0-pre4
+
 ## 1.0.0
 First version of the MLAPI Community Extensions Package.

--- a/com.community.netcode.extensions/Runtime/LagCompensation/FixedQueue.cs
+++ b/com.community.netcode.extensions/Runtime/LagCompensation/FixedQueue.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace Netcode.Extensions.LagCompensation
+{
+    /// <summary>
+    /// Queue with a fixed size
+    /// </summary>
+    /// <typeparam name="T">The type of the queue</typeparam>
+    public sealed class FixedQueue<T>
+    {
+        private readonly T[] m_Queue;
+        private int m_QueueCount = 0;
+        private int m_QueueStart;
+
+        /// <summary>
+        /// The amount of enqueued objects
+        /// </summary>
+        public int Count => m_QueueCount;
+
+        /// <summary>
+        /// Gets the element at a given virtual index
+        /// </summary>
+        /// <param name="index">The virtual index to get the item from</param>
+        /// <returns>The element at the virtual index</returns>
+        public T this[int index] => m_Queue[(m_QueueStart + index) % m_Queue.Length];
+
+        /// <summary>
+        /// Creates a new FixedQueue with a given size
+        /// </summary>
+        /// <param name="maxSize">The size of the queue</param>
+        public FixedQueue(int maxSize)
+        {
+            m_Queue = new T[maxSize];
+            m_QueueStart = 0;
+        }
+
+        /// <summary>
+        /// Enqueues an object
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public bool Enqueue(T t)
+        {
+            m_Queue[(m_QueueStart + m_QueueCount) % m_Queue.Length] = t;
+            if (++m_QueueCount > m_Queue.Length)
+            {
+                --m_QueueCount;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Dequeues an object
+        /// </summary>
+        /// <returns></returns>
+        public T Dequeue()
+        {
+            if (--m_QueueCount == -1)
+            {
+                throw new IndexOutOfRangeException("Cannot dequeue empty queue!");
+            }
+
+            T res = m_Queue[m_QueueStart];
+            m_QueueStart = (m_QueueStart + 1) % m_Queue.Length;
+            return res;
+        }
+
+        /// <summary>
+        /// Gets the element at a given virtual index
+        /// </summary>
+        /// <param name="index">The virtual index to get the item from</param>
+        /// <returns>The element at the virtual index</returns>
+        public T ElementAt(int index) => m_Queue[(m_QueueStart + index) % m_Queue.Length];
+    }
+}

--- a/com.community.netcode.extensions/Runtime/LagCompensation/FixedQueue.cs.meta
+++ b/com.community.netcode.extensions/Runtime/LagCompensation/FixedQueue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae806c2cec088fa42b560ade5270a8cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.community.netcode.extensions/package.json
+++ b/com.community.netcode.extensions/package.json
@@ -1,12 +1,12 @@
 {
   "name": "com.community.netcode.extensions",
   "displayName": "Netcode for GameObjects Community Extensions Package",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "unity": "2019.4",
   "description": "The Netcode for GameObjects Community Extensions package is a package containing extensions to Netcode for GameObjects.",
   "author": "",
   "dependencies": {
-    "com.unity.netcode.gameobjects": "1.0.0-pre.3",
-    "com.unity.netcode.adapter.utp" : "1.0.0-pre.3"
+    "com.unity.netcode.gameobjects": "1.0.0-pre.4",
+    "com.unity.netcode.adapter.utp" : "1.0.0-pre.4"
   }
 }


### PR DESCRIPTION
Adds the FixedQueue to the extensions package. (Was silently removed as a breaking change in the 1.0.0-pre4 release on purpose [1498](https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/1398))

Fixes #140 