### PR TITLE
Facepunch Transport returns RTT and no longer generates garbage for messages

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -188,6 +188,14 @@ namespace Netcode.Transports.Facepunch
 
         private byte[] payloadCache = new byte[4096];
 
+        private void EnsurePayloadCapacity(int size)
+        {
+            if (payloadCache.Length >= size)
+                return;
+
+            payloadCache = new byte[Math.Max(payloadCache.Length * 2, size)];
+        }
+
         void IConnectionManager.OnConnecting(ConnectionInfo info)
         {
             if (LogLevel <= LogLevel.Developer)
@@ -212,10 +220,7 @@ namespace Netcode.Transports.Facepunch
 
         unsafe void IConnectionManager.OnMessage(IntPtr data, int size, long messageNum, long recvTime, int channel)
         {
-            if (payloadCache.Length < size)
-            {
-                payloadCache = new byte[payloadCache.Length * 2];
-            }
+            EnsurePayloadCapacity(size);
 
             fixed (byte* payload = payloadCache)
             {
@@ -268,10 +273,7 @@ namespace Netcode.Transports.Facepunch
 
         unsafe void ISocketManager.OnMessage(SocketConnection connection, NetIdentity identity, IntPtr data, int size, long messageNum, long recvTime, int channel)
         {
-            if (payloadCache.Length < size)
-            {
-                payloadCache = new byte[payloadCache.Length * 2];
-            }
+            EnsurePayloadCapacity(size);
 
             fixed (byte* payload = payloadCache)
             {

--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -212,11 +212,13 @@ namespace Netcode.Transports.Facepunch
 
         unsafe void IConnectionManager.OnMessage(IntPtr data, int size, long messageNum, long recvTime, int channel)
         {
-            if (payloadCache.Length < size) {
+            if (payloadCache.Length < size)
+            {
                 payloadCache = new byte[payloadCache.Length * 2];
             }
 
-            fixed (byte* payload = payloadCache) {
+            fixed (byte* payload = payloadCache)
+            {
                 UnsafeUtility.MemCpy(payload, (byte*)data, size);
             }
 
@@ -266,11 +268,13 @@ namespace Netcode.Transports.Facepunch
 
         unsafe void ISocketManager.OnMessage(SocketConnection connection, NetIdentity identity, IntPtr data, int size, long messageNum, long recvTime, int channel)
         {
-            if (payloadCache.Length < size) {
+            if (payloadCache.Length < size)
+            {
                 payloadCache = new byte[payloadCache.Length * 2];
             }
 
-            fixed (byte* payload = payloadCache) {
+            fixed (byte* payload = payloadCache)
+            {
                 UnsafeUtility.MemCpy(payload, (byte*)data, size);
             }
 


### PR DESCRIPTION
This PR:

* Implements `NetworkTransport.GetCurrentRtt` by returning the `ConnectionStatus.Ping` value.
* Removes all garbage created when data is received from the low level Facepunch/Steamworks transport by using native `MemCpy`.

I've taken a look at a bunch of the other transports, and some could benefit from a similar `MemCpy` approach to avoiding GC. 