### PR TITLE
fix(websocket): add netcode for gameobjects dependency

### DIFF
--- a/Transports/com.community.netcode.transport.websocket/package.json
+++ b/Transports/com.community.netcode.transport.websocket/package.json
@@ -5,5 +5,7 @@
   "unity": "2019.4",
   "description": "WebSocket Transport for Netcode for GameObjects",
   "author": "Nathanael Demacon",
-  "dependencies": {}
+  "dependencies": {
+    "com.unity.netcode.gameobjects": "1.0.0-pre.5"
+  }
 }


### PR DESCRIPTION
Add `"com.unity.netcode.gameobjects": "1.0.0-pre.5"` dependency to websocket transport `package.json`.