### PR TITLE
Update to new NetworkTransport.Initialize signature

### DIFF
--- a/Transports/com.community.netcode.transport.enet/Runtime/EnetTransport.cs
+++ b/Transports/com.community.netcode.transport.enet/Runtime/EnetTransport.cs
@@ -299,7 +299,7 @@ namespace Netcode.Transports.Enet
             Library.Deinitialize();
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             Library.Initialize();
 

--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -104,7 +104,7 @@ namespace Netcode.Transports.Facepunch
             return 0;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             connectedClients = new Dictionary<ulong, Client>();
         }

--- a/Transports/com.community.netcode.transport.litenetlib/Runtime/LiteNetLibTransport.cs
+++ b/Transports/com.community.netcode.transport.litenetlib/Runtime/LiteNetLibTransport.cs
@@ -161,7 +161,7 @@ namespace Netcode.Transports.LiteNetLib
             m_HostType = HostType.None;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             m_MessageBuffer = new byte[MessageBufferSize];
 

--- a/Transports/com.community.netcode.transport.ruffles/Runtime/RufflesTransport.cs
+++ b/Transports/com.community.netcode.transport.ruffles/Runtime/RufflesTransport.cs
@@ -276,7 +276,7 @@ namespace Netcode.Transports.Ruffles
             serverConnection = null;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             messageBuffer = new byte[TransportBufferSize];
 

--- a/Transports/com.community.netcode.transport.steamnetworking/Runtime/SteamNetworkingTransport.cs
+++ b/Transports/com.community.netcode.transport.steamnetworking/Runtime/SteamNetworkingTransport.cs
@@ -194,7 +194,7 @@ namespace Netcode.Transports
             return 0ul;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             if (!IsSupported)
             {

--- a/Transports/com.community.netcode.transport.template/Runtime/TemplateTransport.cs
+++ b/Transports/com.community.netcode.transport.template/Runtime/TemplateTransport.cs
@@ -45,7 +45,7 @@ namespace Netcode.Transports.Template
             throw new NotImplementedException();
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
             throw new NotImplementedException();
         }

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -42,7 +42,7 @@ namespace Netcode.Transports.WebSocket
             return 0;
         }
 
-        public override void Initialize()
+        public override void Initialize(NetworkManager networkManager = null)
         {
 
         }


### PR DESCRIPTION
Update all transports (except Photon, which is already fixed) to the new method signature of `NetworkTransport.Initialize` (it now takes an optional `NetworkManager` as an argument).