### PR TITLE
revert: remove quickstatus (#143)

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -97,10 +97,6 @@ namespace Netcode.Transports.Facepunch
 
         public override unsafe ulong GetCurrentRtt(ulong clientId)
         {
-            if (connectedClients.TryGetValue(clientId, out Client user))
-            {
-                return (ulong)user.connection.QuickStatus().Ping;
-            }
             return 0;
         }
 


### PR DESCRIPTION
Revert the add of quickstatus (#143) which was used to fetch the ping for connected clients. This API is currently not in a release version of Facepunch. We can add it back later once it is supported.