### PR TITLE
Addressing #171 by completely commenting out NetworkDictionary so it won't break everything by being here

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
@@ -5,6 +5,11 @@ using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Netcode
 {
+
+    // TODO: uncomment this when 'Write' and 'Read' in NetworkVariableSerialization (see https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/blob/develop/com.unity.netcode.gameobjects/Runtime/NetworkVariable/NetworkVariableSerialization.cs).
+    // are no longer internal, so this class will actually work.
+
+    /*
     public class FixedStringKeyedNetworkDictionary<TKey, TValue> : NetworkDictionary<TKey, TValue>
         where TKey : unmanaged, INativeList<byte>, IUTF8Bytes, IEquatable<TKey>
         where TValue : unmanaged
@@ -470,4 +475,5 @@ namespace Unity.Netcode
         /// </summary>
         public TValue PreviousValue;
     }
+    */
 }


### PR DESCRIPTION
Because Unity changed NetworkVariableSerialization's 'Read' and 'Write' methods (in Netcode for GameObjects itself) to be internal, NetworkDictionary doesn't work, and #171 is unfixable neatly until that problem is fixed. Therefore, I have used the nuclear option of just commenting out NetworkDictionary, at least whilst we wait for Netcode for GameObjects to be fixed (by making Write and Read in NetworkVariableSerialization not internal)

See https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/issues/2043 for further details.