### PR TITLE
fix: port NetworkDictionary to 1.0.0 (stable)

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.asmref
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "Unity.Netcode.Runtime"
+}

--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.asmref.meta
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 287c8c2ccc937174691fc6cac804f3bc
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
@@ -1,84 +1,60 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 
 namespace Unity.Netcode
 {
-    public class FixedStringKeyedNetworkDictionary<TKey, TValue> : NetworkDictionary<TKey, TValue>
-        where TKey : unmanaged, INativeList<byte>, IUTF8Bytes, IEquatable<TKey>
-        where TValue : unmanaged
-    {
-        public FixedStringKeyedNetworkDictionary() { }
-
-        public FixedStringKeyedNetworkDictionary(NetworkVariableReadPermission readPerm, IDictionary<TKey, TValue> values) : base(readPerm, values) { }
-
-        public FixedStringKeyedNetworkDictionary(IDictionary<TKey, TValue> values) : base(values) { }
-
-        protected override void WriteKey(FastBufferWriter writer, TKey key) => writer.WriteValueSafe(new ForceNetworkSerializeByMemcpy<TKey>(key));
-
-        protected override void ReadKey(FastBufferReader reader, out TKey key)
-        {
-            reader.ReadValueSafe(out ForceNetworkSerializeByMemcpy<TKey> serializedKey);
-            key = serializedKey.Value;
-        }
-    }
-
-    public class EnumKeyedNetworkDictionary<TKey, TValue> : NetworkDictionary<TKey, TValue>
-        where TKey : unmanaged, Enum, IEquatable<TKey>
-        where TValue : unmanaged
-    {
-        public EnumKeyedNetworkDictionary() { }
-
-        public EnumKeyedNetworkDictionary(NetworkVariableReadPermission readPerm, IDictionary<TKey, TValue> values) : base(readPerm, values) { }
-
-        public EnumKeyedNetworkDictionary(IDictionary<TKey, TValue> values) : base(values) { }
-
-        protected override void WriteKey(FastBufferWriter writer, TKey key) => writer.WriteValueSafe(key);
-
-        protected override void ReadKey(FastBufferReader reader, out TKey key) => reader.ReadValueSafe(out key);
-    }
-
-    public class PrimitiveKeyedNetworkDictionary<TKey, TValue> : NetworkDictionary<TKey, TValue>
-        where TKey : unmanaged, IComparable, IConvertible, IComparable<TKey>, IEquatable<TKey>
-        where TValue : unmanaged
-    {
-        public PrimitiveKeyedNetworkDictionary() { }
-
-        public PrimitiveKeyedNetworkDictionary(NetworkVariableReadPermission readPerm, IDictionary<TKey, TValue> values) : base(readPerm, values) { }
-
-        public PrimitiveKeyedNetworkDictionary(IDictionary<TKey, TValue> values) : base(values) { }
-
-        protected override void WriteKey(FastBufferWriter writer, TKey key) => writer.WriteValueSafe(key);
-
-        protected override void ReadKey(FastBufferReader reader, out TKey key) => reader.ReadValueSafe(out key);
-    }
-
-    public class StructKeyedNetworkDictionary<TKey, TValue> : NetworkDictionary<TKey, TValue>
-        where TKey : unmanaged, INetworkSerializeByMemcpy, IEquatable<TKey>
-        where TValue : unmanaged
-    {
-        public StructKeyedNetworkDictionary() { }
-
-        public StructKeyedNetworkDictionary(NetworkVariableReadPermission readPerm, IDictionary<TKey, TValue> values) : base(readPerm, values) { }
-
-        public StructKeyedNetworkDictionary(IDictionary<TKey, TValue> values) : base(values) { }
-
-        protected override void WriteKey(FastBufferWriter writer, TKey key) => writer.WriteValueSafe(key);
-
-        protected override void ReadKey(FastBufferReader reader, out TKey key) => reader.ReadValueSafe(out key);
-    }
-
     /// <summary>
     /// Event based NetworkVariable container for syncing Dictionaries
     /// </summary>
     /// <typeparam name="TKey">The type for the dictionary keys</typeparam>
     /// <typeparam name="TValue">The type for the dictionary values</typeparam>
-    public abstract class NetworkDictionary<TKey, TValue> : NetworkVariableSerialization<TValue>
+    public class NetworkDictionary<TKey, TValue> : NetworkVariableBase
         where TKey : unmanaged, IEquatable<TKey>
         where TValue : unmanaged
     {
-        private NativeHashMap<TKey, TValue> m_Dictionary = new NativeHashMap<TKey, TValue>(64, Allocator.Persistent);
+        public struct Enumerator : IEnumerator<(TKey Key, TValue Value)>
+        {
+            private NativeArray<TKey> keys;
+            private NativeArray<TKey>.Enumerator keysEnumerator;
+            private NativeArray<TValue> values;
+            private NativeArray<TValue>.Enumerator valuesEnumerator;
+
+            public (TKey Key, TValue Value) Current => (keysEnumerator.Current, valuesEnumerator.Current);
+
+            object IEnumerator.Current => Current;
+
+            public Enumerator(ref NativeList<TKey> keys, ref NativeList<TValue> values)
+            {
+                this.keys = keys.AsArray();
+                this.values = values.AsArray();
+                keysEnumerator = new NativeArray<TKey>.Enumerator(ref this.keys);
+                valuesEnumerator = new NativeArray<TValue>.Enumerator(ref this.values);
+            }
+
+            public void Dispose() { }
+
+            public bool MoveNext()
+            {
+                var keysEnumeratorCanMove = keysEnumerator.MoveNext();
+                var valuesEnumeratorCanMove = valuesEnumerator.MoveNext();
+
+                return keysEnumeratorCanMove && valuesEnumeratorCanMove;
+            }
+
+            public void Reset()
+            {
+                keysEnumerator.Reset();
+                valuesEnumerator.Reset();
+            }
+        }
+
+        private NativeList<TKey> m_Keys = new NativeList<TKey>(64, Allocator.Persistent);
+        private NativeList<TValue> m_Values = new NativeList<TValue>(64, Allocator.Persistent);
+        private NativeList<TKey> m_KeysAtLastReset = new NativeList<TKey>(64, Allocator.Persistent);
+        private NativeList<TValue> m_ValuesAtLastReset = new NativeList<TValue>(64, Allocator.Persistent);
         private NativeList<NetworkDictionaryEvent<TKey, TValue>> m_DirtyEvents = new NativeList<NetworkDictionaryEvent<TKey, TValue>>(64, Allocator.Persistent);
 
         /// <summary>
@@ -95,18 +71,19 @@ namespace Unity.Netcode
         /// <summary>
         /// Creates a NetworkDictionary with the default value and settings
         /// </summary>
-        protected NetworkDictionary() { }
+        public NetworkDictionary() { }
 
         /// <summary>
         /// Creates a NetworkDictionary with the default value and custom settings
         /// </summary>
         /// <param name="readPerm">The read permission to use for the NetworkDictionary</param>
         /// <param name="values">The initial value to use for the NetworkDictionary</param>
-        protected NetworkDictionary(NetworkVariableReadPermission readPerm, IDictionary<TKey, TValue> values) : base(readPerm)
+        public NetworkDictionary(NetworkVariableReadPermission readPerm, IDictionary<TKey, TValue> values) : base(readPerm)
         {
             foreach (var pair in values)
             {
-                m_Dictionary.Add(pair.Key, pair.Value);
+                m_Keys.Add(pair.Key);
+                m_Values.Add(pair.Value);
             }
         }
 
@@ -114,11 +91,12 @@ namespace Unity.Netcode
         /// Creates a NetworkDictionary with a custom value and custom settings
         /// </summary>
         /// <param name="values">The initial value to use for the NetworkDictionary</param>
-        protected NetworkDictionary(IDictionary<TKey, TValue> values)
+        public NetworkDictionary(IDictionary<TKey, TValue> values)
         {
             foreach (var pair in values)
             {
-                m_Dictionary.Add(pair.Key, pair.Value);
+                m_Keys.Add(pair.Key);
+                m_Values.Add(pair.Value);
             }
         }
 
@@ -126,7 +104,13 @@ namespace Unity.Netcode
         public override void ResetDirty()
         {
             base.ResetDirty();
-            m_DirtyEvents.Clear();
+
+            if (m_DirtyEvents.Length > 0)
+            {
+                m_DirtyEvents.Clear();
+                m_KeysAtLastReset.CopyFrom(m_Keys);
+                m_ValuesAtLastReset.CopyFrom(m_Values);
+            }
         }
 
         /// <inheritdoc />
@@ -148,25 +132,26 @@ namespace Unity.Netcode
 
             for (int i = 0; i < m_DirtyEvents.Length; i++)
             {
+                var element = m_DirtyEvents.ElementAt(i);
                 writer.WriteValueSafe(m_DirtyEvents[i].Type);
 
                 switch (m_DirtyEvents[i].Type)
                 {
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Add:
                         {
-                            WriteKey(writer, m_DirtyEvents[i].Key);
-                            Write(writer, m_DirtyEvents[i].Value);
+                            NetworkVariableSerialization<TKey>.Write(writer, ref element.Key);
+                            NetworkVariableSerialization<TValue>.Write(writer, ref element.Value);
                         }
                         break;
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Remove:
                         {
-                            WriteKey(writer, m_DirtyEvents[i].Key);
+                            NetworkVariableSerialization<TKey>.Write(writer, ref element.Key);
                         }
                         break;
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Value:
                         {
-                            WriteKey(writer, m_DirtyEvents[i].Key);
-                            Write(writer, m_DirtyEvents[i].Value);
+                            NetworkVariableSerialization<TKey>.Write(writer, ref element.Key);
+                            NetworkVariableSerialization<TValue>.Write(writer, ref element.Value);
                         }
                         break;
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Clear:
@@ -180,30 +165,48 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public override void WriteField(FastBufferWriter writer)
         {
-            writer.WriteValueSafe((ushort)m_Dictionary.Count());
+            // The keysAtLastReset and valuesAtLastReset mechanism was put in place to deal with duplicate adds
+            // upon initial spawn. However, it causes issues with in-scene placed objects
+            // due to difference in spawn order. In order to address this, we pick the right
+            // list based on the type of object.
+            bool isSceneObject = m_NetworkBehaviour.NetworkObject.IsSceneObject != false;
 
-            foreach (var pair in m_Dictionary)
+            if (isSceneObject)
             {
-                WriteKey(writer, pair.Key);
-                Write(writer, pair.Value);
+                writer.WriteValueSafe((ushort)m_KeysAtLastReset.Length);
+
+                for (int i = 0; i < m_KeysAtLastReset.Length; i++)
+                {
+                    NetworkVariableSerialization<TKey>.Write(writer, ref m_KeysAtLastReset.ElementAt(i));
+                    NetworkVariableSerialization<TValue>.Write(writer, ref m_ValuesAtLastReset.ElementAt(i));
+                }
+            }
+            else
+            {
+                writer.WriteValueSafe((ushort)m_Keys.Length);
+
+                for (int i = 0; i < m_Keys.Length; i++)
+                {
+                    NetworkVariableSerialization<TKey>.Write(writer, ref m_Keys.ElementAt(i));
+                    NetworkVariableSerialization<TValue>.Write(writer, ref m_Values.ElementAt(i));
+                }
             }
         }
-
-        protected abstract void WriteKey(FastBufferWriter writer, TKey key);
-
-        protected abstract void ReadKey(FastBufferReader reader, out TKey key);
 
         /// <inheritdoc />
         public override void ReadField(FastBufferReader reader)
         {
-            m_Dictionary.Clear();
+            m_Keys.Clear();
+            m_Values.Clear();
+
             reader.ReadValueSafe(out ushort count);
 
             for (int i = 0; i < count; i++)
             {
-                ReadKey(reader, out TKey key);
-                Read(reader, out TValue value);
-                m_Dictionary.Add(key, value);
+                NetworkVariableSerialization<TKey>.Read(reader, out TKey key);
+                NetworkVariableSerialization<TValue>.Read(reader, out TValue value);
+                m_Keys.Add(key);
+                m_Values.Add(value);
             }
         }
 
@@ -220,9 +223,16 @@ namespace Unity.Netcode
                 {
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Add:
                         {
-                            ReadKey(reader, out TKey key);
-                            Read(reader, out TValue value);
-                            m_Dictionary.Add(key, value);
+                            NetworkVariableSerialization<TKey>.Read(reader, out TKey key);
+                            NetworkVariableSerialization<TValue>.Read(reader, out TValue value);
+
+                            if (m_Keys.Contains(key))
+                            {
+                                throw new Exception("Shouldn't be here, key already exists in dictionary");
+                            }
+
+                            m_Keys.Add(key);
+                            m_Values.Add(value);
 
                             OnDictionaryChanged?.Invoke(new NetworkDictionaryEvent<TKey, TValue>
                             {
@@ -244,9 +254,17 @@ namespace Unity.Netcode
                         break;
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Remove:
                         {
-                            ReadKey(reader, out TKey key);
-                            m_Dictionary.TryGetValue(key, out TValue value);
-                            m_Dictionary.Remove(key);
+                            NetworkVariableSerialization<TKey>.Read(reader, out TKey key);
+                            var index = m_Keys.IndexOf(key);
+
+                            if (index == -1)
+                            {
+                                break;
+                            }
+
+                            var value = m_Values.ElementAt(index);
+                            m_Keys.RemoveAt(index);
+                            m_Values.RemoveAt(index);
 
                             OnDictionaryChanged?.Invoke(new NetworkDictionaryEvent<TKey, TValue>
                             {
@@ -268,11 +286,17 @@ namespace Unity.Netcode
                         break;
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Value:
                         {
-                            ReadKey(reader, out TKey key);
-                            Read(reader, out TValue value);
+                            NetworkVariableSerialization<TKey>.Read(reader, out TKey key);
+                            NetworkVariableSerialization<TValue>.Read(reader, out TValue value);
+                            var index = m_Keys.IndexOf(key);
 
-                            m_Dictionary.TryGetValue(key, out TValue previousValue);
-                            m_Dictionary[key] = value;
+                            if (index == -1)
+                            {
+                                throw new Exception("Shouldn't be here, key doesn't exist in dictionary");
+                            }
+
+                            var previousValue = m_Values.ElementAt(index);
+                            m_Values[index] = value;
 
                             OnDictionaryChanged?.Invoke(new NetworkDictionaryEvent<TKey, TValue>
                             {
@@ -296,7 +320,8 @@ namespace Unity.Netcode
                         break;
                     case NetworkDictionaryEvent<TKey, TValue>.EventType.Clear:
                         {
-                            m_Dictionary.Clear();
+                            m_Keys.Clear();
+                            m_Values.Clear();
 
                             OnDictionaryChanged?.Invoke(new NetworkDictionaryEvent<TKey, TValue>
                             {
@@ -317,12 +342,18 @@ namespace Unity.Netcode
         }
 
         /// <inheritdoc />
-        public IEnumerator<KeyValue<TKey, TValue>> GetEnumerator() => m_Dictionary.GetEnumerator();
+        public IEnumerator<(TKey Key, TValue Value)> GetEnumerator() => new Enumerator(ref m_Keys, ref m_Values);
 
         /// <inheritdoc />
         public void Add(TKey key, TValue value)
         {
-            m_Dictionary.Add(key, value);
+            if (m_Keys.Contains(key))
+            {
+                throw new Exception("Shouldn't be here, key already exists in dictionary");
+            }
+
+            m_Keys.Add(key);
+            m_Values.Add(value);
 
             var dictionaryEvent = new NetworkDictionaryEvent<TKey, TValue>()
             {
@@ -337,7 +368,8 @@ namespace Unity.Netcode
         /// <inheritdoc />
         public void Clear()
         {
-            m_Dictionary.Clear();
+            m_Keys.Clear();
+            m_Values.Clear();
 
             var dictionaryEvent = new NetworkDictionaryEvent<TKey, TValue>()
             {
@@ -348,13 +380,21 @@ namespace Unity.Netcode
         }
 
         /// <inheritdoc />
-        public bool ContainsKey(TKey key) => m_Dictionary.ContainsKey(key);
+        public bool ContainsKey(TKey key) => m_Keys.Contains(key);
 
         /// <inheritdoc />
         public bool Remove(TKey key)
         {
-            m_Dictionary.TryGetValue(key, out TValue value);
-            m_Dictionary.Remove(key);
+            var index = m_Keys.IndexOf(key);
+
+            if (index == -1)
+            {
+                return false;
+            }
+
+            var value = m_Values[index];
+            m_Keys.RemoveAt(index);
+            m_Values.RemoveAt(index);
 
             var dictionaryEvent = new NetworkDictionaryEvent<TKey, TValue>()
             {
@@ -369,24 +409,54 @@ namespace Unity.Netcode
         }
 
         /// <inheritdoc />
-        public bool TryGetValue(TKey key, out TValue value) => m_Dictionary.TryGetValue(key, out value);
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            var index = m_Keys.IndexOf(key);
+
+            if (index == -1)
+            {
+                value = default;
+                return false;
+            }
+
+            value = m_Values[index];
+            return true;
+        }
 
         /// <inheritdoc />
-        public int Count => m_Dictionary.Count();
+        public int Count => m_Keys.Length;
 
         /// <inheritdoc />
-        public IEnumerable<TKey> Keys => m_Dictionary.GetKeyArray(Allocator.Temp).ToArray();
+        public IEnumerable<TKey> Keys => m_Keys.ToArray();
 
         /// <inheritdoc />
-        public IEnumerable<TValue> Values => m_Dictionary.GetValueArray(Allocator.Temp).ToArray();
+        public IEnumerable<TValue> Values => m_Values.ToArray();
 
         /// <inheritdoc />
         public TValue this[TKey key]
         {
-            get => m_Dictionary[key];
+            get
+            {
+                var index = m_Keys.IndexOf(key);
+
+                if (index == -1)
+                {
+                    throw new Exception("Shouldn't be here, key doesn't exist in dictionary");
+                }
+
+                return m_Values[index];
+            }
             set
             {
-                m_Dictionary[key] = value;
+                var index = m_Keys.IndexOf(key);
+
+                if (index == -1)
+                {
+                    Add(key, value);
+                    return;
+                }
+
+                m_Values[index] = value;
 
                 var dictionaryEvent = new NetworkDictionaryEvent<TKey, TValue>()
                 {
@@ -407,7 +477,10 @@ namespace Unity.Netcode
 
         public override void Dispose()
         {
-            m_Dictionary.Dispose();
+            m_Keys.Dispose();
+            m_Values.Dispose();
+            m_KeysAtLastReset.Dispose();
+            m_ValuesAtLastReset.Dispose();
             m_DirtyEvents.Dispose();
         }
     }

--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NETWORK_DICTIONARY
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.Collections;
@@ -544,3 +546,5 @@ namespace Unity.Netcode
         public TValue PreviousValue;
     }
 }
+
+#endif

--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/README.md
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/README.md
@@ -1,0 +1,6 @@
+# How to use NetworkDictionary
+
+In order to make NetworkDictionary available to your codebase you need to use at least Netcode for GameObject version 1.0.0 (stable).  
+You'll also have to define the scripting define symbol `NETWORK_DICTIONARY`.  
+To do that, go to `Edit` -> `Project Settings` -> `Player` -> `Script Compilation` -> `Scripting Define Symbols` and add `NETWORK_DICTIONARY` to the list.  
+Then wait for recompilation and enjoy!


### PR DESCRIPTION
`internal static void Write` and `internal static void Read` methods of the `public static class NetworkVariableSerialization<T>` (NetworkVariableSerialization.cs) of the NGO's package have to be made `public` in order to make this implementation work.

OR

You can add an Assembly definition reference (.asmref) next to this file pointing to the NGO's package. It'll make Unity consider this file as it was part of the NGO's package and effectively give it access to all NGO's `internal` methods. 