### PR TITLE
Fix NetworkDictionary not working

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
@@ -474,7 +474,13 @@ namespace Unity.Netcode
         private void HandleAddDictionaryEvent(NetworkDictionaryEvent<TKey, TValue> dictionaryEvent)
         {
             m_DirtyEvents.Add(dictionaryEvent);
+            MarkNetworkObjectDirty();
             OnDictionaryChanged?.Invoke(dictionaryEvent);
+        }
+
+        internal void MarkNetworkObjectDirty()
+        {
+            m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
         }
 
         public override void Dispose()


### PR DESCRIPTION
NetworkDictionary was not marking the underlying NetworkBehaviour as dirty, and hence its changes were never processed.