### PR TITLE
fix: WebSocketTransport Re-use and Compatibility

### DIFF
--- a/Transports/com.community.netcode.transport.websocket/Runtime/JSWebSocketClient.jslib
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/JSWebSocketClient.jslib
@@ -39,7 +39,7 @@ var LibraryWebSocket = {
       }
 
       if (state.onOpen) {
-        Runtime.dynCall('v', state.onOpen, []);
+        Module['dynCall_v'](state.onOpen);
       }
     };
 
@@ -59,7 +59,7 @@ var LibraryWebSocket = {
         HEAPU8.set(dataBuffer, buffer);
 
         try {
-          Runtime.dynCall('vii', state.onMessage, [buffer, dataBuffer.length]);
+          Module['dynCall_vii'](state.onMessage, buffer, dataBuffer.length);
         } finally {
           _free(buffer);
         }
@@ -78,7 +78,7 @@ var LibraryWebSocket = {
         stringToUTF8(msg, msgBuffer, msgBytes);
 
         try {
-          Runtime.dynCall('vi', state.onError, [msgBuffer]);
+          Module['dynCall_vi'](state.onError, msgBuffer)
         } finally {
           _free(msgBuffer);
         }
@@ -91,7 +91,7 @@ var LibraryWebSocket = {
       }
 
       if (state.onClose) {
-        Runtime.dynCall('vi', state.onClose, [ev.code]);
+        Module['dynCall_vi'](state.onClose, ev.code)
       }
     };
   },

--- a/Transports/com.community.netcode.transport.websocket/Runtime/NativeWebSocketClient.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/NativeWebSocketClient.cs
@@ -63,11 +63,6 @@ namespace Netcode.Transports.WebSocket
 
         public void Close(CloseStatusCode code = CloseStatusCode.Normal, string reason = null)
         {
-            if (Connection == null)
-            {
-                return;
-            }
-
             if (ReadyState == WebSocketSharp.WebSocketState.Closing)
             {
                 throw new InvalidOperationException("Socket is already closing");
@@ -75,7 +70,7 @@ namespace Netcode.Transports.WebSocket
 
             if (ReadyState == WebSocketSharp.WebSocketState.Closed)
             {
-                throw new InvalidOperationException("Socket is already closed");
+                return;
             }
 
             try

--- a/Transports/com.community.netcode.transport.websocket/Runtime/NativeWebSocketClient.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/NativeWebSocketClient.cs
@@ -63,6 +63,11 @@ namespace Netcode.Transports.WebSocket
 
         public void Close(CloseStatusCode code = CloseStatusCode.Normal, string reason = null)
         {
+            if (Connection == null)
+            {
+                return;
+            }
+
             if (ReadyState == WebSocketSharp.WebSocketState.Closing)
             {
                 throw new InvalidOperationException("Socket is already closing");

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketClientFactory.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketClientFactory.cs
@@ -10,8 +10,8 @@ namespace Netcode.Transports.WebSocket
 {
     public class WebSocketClientFactory
     {
-#if UNITY_WEBGL
-        public static JSWebSocketClient Client = new JSWebSocketClient();
+#if (UNITY_WEBGL && !UNITY_EDITOR)
+        public static JSWebSocketClient Client;
 
         internal delegate void OnOpenCallback();
         internal delegate void OnMessageCallback(IntPtr messagePointer, int messageSize);
@@ -67,7 +67,8 @@ namespace Netcode.Transports.WebSocket
 
         public static IWebSocketClient Create(string url)
         {
-#if UNITY_WEBGL
+#if (UNITY_WEBGL && !UNITY_EDITOR)
+            Client = new JSWebSocketClient()
             _SetUrl(url);
             _SetOnOpen(OnOpenEvent);
             _SetOnMessage(OnMessageEvent);

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketClientFactory.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketClientFactory.cs
@@ -68,7 +68,7 @@ namespace Netcode.Transports.WebSocket
         public static IWebSocketClient Create(string url)
         {
 #if (UNITY_WEBGL && !UNITY_EDITOR)
-            Client = new JSWebSocketClient()
+            Client = new JSWebSocketClient();
             _SetUrl(url);
             _SetOnOpen(OnOpenEvent);
             _SetOnMessage(OnMessageEvent);

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -8,9 +8,9 @@ namespace Netcode.Transports.WebSocket
 {
     public class WebSocketTransport : NetworkTransport
     {
-        private static WebSocketServer WebSocketServer = null;
-        private static IWebSocketClient WebSocketClient = null;
-        private static bool IsStarted = false;
+        private WebSocketServer WebSocketServer = null;
+        private IWebSocketClient WebSocketClient = null;
+        private bool IsStarted = false;
 
         [Header("Transport")]
         public string ConnectAddress = "127.0.0.1";

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -97,7 +97,6 @@ namespace Netcode.Transports.WebSocket
             if (WebSocketClient != null)
             {
                 WebSocketClient.Close();
-                WebSocketClient = null;
             }
             else if (WebSocketServer != null)
             {

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -23,13 +23,11 @@ namespace Netcode.Transports.WebSocket
 
         public override void DisconnectLocalClient()
         {
-            IsStarted = false;
             WebSocketClient.Close();
         }
 
         public override void DisconnectRemoteClient(ulong clientId)
         {
-            IsStarted = false;
             WebSocketServerConnectionBehavior.DisconnectClient(clientId);
         }
 
@@ -95,6 +93,7 @@ namespace Netcode.Transports.WebSocket
 
         public override void Shutdown()
         {
+            IsStarted = false;
             if (WebSocketClient != null)
             {
                 WebSocketClient.Close();

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -97,6 +97,7 @@ namespace Netcode.Transports.WebSocket
             if (WebSocketClient != null)
             {
                 WebSocketClient.Close();
+                WebSocketClient = null;
             }
             else if (WebSocketServer != null)
             {

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -93,7 +93,6 @@ namespace Netcode.Transports.WebSocket
 
         public override void Shutdown()
         {
-            IsStarted = false;
             if (WebSocketClient != null)
             {
                 WebSocketClient.Close();
@@ -102,6 +101,7 @@ namespace Netcode.Transports.WebSocket
             {
                 WebSocketServer.Stop();
             }
+            IsStarted = false;
         }
 
         public override bool StartClient()

--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -23,11 +23,13 @@ namespace Netcode.Transports.WebSocket
 
         public override void DisconnectLocalClient()
         {
+            IsStarted = false;
             WebSocketClient.Close();
         }
 
         public override void DisconnectRemoteClient(ulong clientId)
         {
+            IsStarted = false;
             WebSocketServerConnectionBehavior.DisconnectClient(clientId);
         }
 


### PR DESCRIPTION
Adjusted web socket transport so it can be re-used multiple times and not rely on static fields to manage state.
This way a player can connect, disconnect, and reconnect without having to re-create the web socket transport.

Also included changes from PR #174 to change references in `JSWebSocketClient.jslib` to use `Module['dynCall_vii']` instead of `Runtime.dynCall('v', _, []);` to get around the error: `ReferenceError: Runtime is not defined`

Found that the variable `Runtime` no longer exists in more recent versions of the WebGL build for unity. Would it be best to make two versions of these calls based on a flag like if the unity build is before/after v2021.2 to decide if that flag should be used?
https://stackoverflow.com/questions/70411564/unity-webgl-throws-error-referenceerror-runtime-is-not-defined
> It seams that in unity 2021.2 variable Runtime doesn't exist and can be replaced with Module['dynCall_*'].
> 
> In webSocket.jslib change all Runtime.dynCall('*1', *2, [*3, *4]) for Module['dynCall_*1'](*2, *3, *4)
> 
> Example instance.ws.onopen function in WebSocket.jslib:
> 
> ```
> change Runtime.dynCall('vi', webSocketState.onOpen, [ instanceId ]);
> for
> Module['dynCall_vi'](webSocketState.onOpen, instanceId);
> ```

Ran into an error with the NativeWebSocket.cs being marked as closed so avoided that error as it didn't seem to catch any edge cases when closing an already closed native session. Any feedback on this part is appreciated. It seems like the existing case of connecting one still works so it's not "more broken" than it was before but if there is a more graceful solution, I'm happy to adjust based on feedback. It seems like the `close` method of the socket was being called after the socket was already closed and I'm not sure if this is because the websocket transport was originally designed to be run once or if it's just some compatibility issues with netcode v1.1.0. 

I have a working example using this websocket transport in my repo https://github.com/nicholas-maltbie/NetworkStateMachineUnity An example of the project running in the browser is hosted here via github pages: https://nickmaltbie.com/NetworkStateMachineUnity/

I specifically referenced my branch in the changes to ensure they work as expected:

```
"com.community.netcode.transport.websocket": "git+https://github.com/nicholas-maltbie/multiplayer-community-contributions?path=/Transports/com.community.netcode.transport.websocket#webgl-patch",
```

I was able to have multiple browser sessions connect to a host I execute locally. The project doesn't have much documentation but there will be buttons to start host/server mode when running in a non WebGL client. The WebGL client doesn't support server mode so it can only function as a client. 
