### PR TITLE
Fix NRE (NullReferenceException)

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -75,7 +75,7 @@ namespace Netcode.Transports.Facepunch
 
         public override void DisconnectLocalClient()
         {
-            connectionManager.Connection.Close();
+            connectionManager?.Connection.Close();
 
             if (LogLevel <= LogLevel.Developer)
                 Debug.Log($"[{nameof(FacepunchTransport)}] - Disconnecting local client.");


### PR DESCRIPTION
This small little fix follows suit in the other places where connectionManager, and uses the null check ? `connectionManager?.Connection.Close();` as other places do. This fixes the NRE (NullReferenceException) that happens after play mode on NetCode 1.2.0 it seems. :)