### PR TITLE
Add option to configure websocket path

### DIFF
--- a/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/WebSocketTransport.cs
@@ -14,6 +14,7 @@ namespace Netcode.Transports.WebSocket
 
         [Header("Transport")]
         public string ConnectAddress = "127.0.0.1";
+        public string Path = "/netcode";
         public ushort Port = 7777;
         public bool SecureConnection = false;
         public bool AllowForwardedRequest;
@@ -112,7 +113,7 @@ namespace Netcode.Transports.WebSocket
             }
 
             var protocol = SecureConnection ? "wss" : "ws";
-            WebSocketClient = WebSocketClientFactory.Create($"{protocol}://{ConnectAddress}:{Port}/netcode");
+            WebSocketClient = WebSocketClientFactory.Create($"{protocol}://{ConnectAddress}:{Port}{Path}");
             WebSocketClient.Connect();
 
             IsStarted = true;
@@ -129,7 +130,7 @@ namespace Netcode.Transports.WebSocket
             
             WebSocketServer = new WebSocketServer(Port, SecureConnection);
             WebSocketServer.AllowForwardedRequest = AllowForwardedRequest;
-            WebSocketServer.AddWebSocketService<WebSocketServerConnectionBehavior>("/netcode");
+            WebSocketServer.AddWebSocketService<WebSocketServerConnectionBehavior>(Path);
             if (!string.IsNullOrEmpty(CertificateBase64String))
             {
                 var bytes = Convert.FromBase64String(CertificateBase64String);


### PR DESCRIPTION
This path was hardcoded to `/netcode` which is not necessary for websocket connections, and is an opinionated choice that breaks in certain reverse proxy configurations such as using domains per game server with certs for WSS connections from the browser.

The only way to use the transport in an actual professional setting is to fork and delete the path out of the code, which this lets the user do now without modifying the code.

Web sockets are not required to listen on any path at all. This allows users to delete the path but the default does not break backwards compatibility.

Using this in production for our unity re-write of https://rolltable.app

![Screen Shot 2023-01-14 at 4 27 01 PM](https://user-images.githubusercontent.com/458976/212497750-d9844336-fb21-42ff-b217-a79b3f81b689.png)
