### PR TITLE
fix null reference exception in steam transport when shutting down a host

### DIFF
--- a/Transports/com.community.netcode.transport.steamnetworkingsockets/Runtime/SteamNetworkingSocketsTransport.cs
+++ b/Transports/com.community.netcode.transport.steamnetworkingsockets/Runtime/SteamNetworkingSocketsTransport.cs
@@ -60,14 +60,16 @@ namespace Netcode.Transports
         {
             if (NetworkManager.Singleton.LogLevel <= LogLevel.Developer) NetworkLog.LogInfoServer(nameof(SteamNetworkingSocketsTransport) + " - DisconnectLocalClient");
 
-            if (connectionMapping.ContainsKey(serverUser.id.m_SteamID))
-                connectionMapping.Remove(serverUser.id.m_SteamID);
+            if (serverUser != null) {
+                if (connectionMapping.ContainsKey(serverUser.id.m_SteamID))
+                    connectionMapping.Remove(serverUser.id.m_SteamID);
 #if UNITY_SERVER
-            SteamGameServerNetworkingSockets.CloseConnection(serverUser.connection, 0, "Disconnected", false);
+                SteamGameServerNetworkingSockets.CloseConnection(serverUser.connection, 0, "Disconnected", false);
 #else
-            SteamNetworkingSockets.CloseConnection(serverUser.connection, 0, "Disconnected", false);
+                SteamNetworkingSockets.CloseConnection(serverUser.connection, 0, "Disconnected", false);
 #endif
-            serverUser = null;
+                serverUser = null;
+            }
         }
 
         public override void DisconnectRemoteClient(ulong clientId)


### PR DESCRIPTION
with netcode for gameobjects 1.2.0, DisconnectLocalClient can get called without setting up serverUser when starting a host

fixed #192 for me