### PR TITLE
fix: Flush pending messages server side when a client is disconnected

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -85,6 +85,8 @@ namespace Netcode.Transports.Facepunch
         {
             if (connectedClients.TryGetValue(clientId, out Client user))
             {
+                // Flush any pending messages before closing the connection
+                user.connection.Flush();
                 user.connection.Close();
                 connectedClients.Remove(clientId);
 


### PR DESCRIPTION
This just makes sure to flush any pending messages before closing the connection.