### PR TITLE
fix: Facepunch.Steamworks assembly reference couldn't be found

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/Facepunch/Facepunch.Steamworks.Posix.dll.meta
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/Facepunch/Facepunch.Steamworks.Posix.dll.meta
@@ -33,7 +33,7 @@ PluginImporter:
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
-        OS: OSX
+        OS: AnyOS
   - first:
       Facebook: Win
     second:


### PR DESCRIPTION
Facepunch Steamworks assembly reference couldn't be found when I tried to use Facepunch transport on Fedora 38 with Unity 2021.3.23f1 installed. I fixed it by modifying the assembly's info and changing its platform settings (changed target OS from OSX to Any OS).