### PR TITLE
Update NetworkObjectPool.cs

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkObjectPool/NetworkObjectPool.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkObjectPool/NetworkObjectPool.cs
@@ -246,6 +246,4 @@ namespace Netcode.Extensions
             m_Pool.ReturnNetworkObject(networkObject, m_Prefab);
         }
     }
-
-}
 }


### PR DESCRIPTION
Erroneous curly brace, causing Unity errors:

`Assets/com.community.netcode.extensions/Runtime/NetworkObjectPool/NetworkObjectPool.cs(251,1): error CS1022: Type or namespace definition, or end-of-file expected
`