### PR TITLE
Fixed NetworkDictionary for v1.5.1

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDictionary/NetworkDictionary.cs
@@ -480,7 +480,7 @@ namespace Unity.Netcode
 
         internal void MarkNetworkObjectDirty()
         {
-            m_NetworkBehaviour.NetworkManager.MarkNetworkObjectDirty(m_NetworkBehaviour.NetworkObject);
+            m_NetworkBehaviour.NetworkManager.BehaviourUpdater.AddForUpdate(m_NetworkBehaviour.NetworkObject);
         }
 
         public override void Dispose()


### PR DESCRIPTION
updated the MarkNetworkObjectDirty() to adhere to v1.5.1