### PR TITLE
Removed "using" deprecated UNET transports

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkDiscovery/ExampleNetworkDiscoveryHud.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDiscovery/ExampleNetworkDiscoveryHud.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using Unity.Netcode;
-using Unity.Netcode.Transports.UNET;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 using Object = UnityEngine.Object;

--- a/com.community.netcode.extensions/Runtime/NetworkManagerHud/NetworkManagerHud.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkManagerHud/NetworkManagerHud.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using Unity.Netcode;
-using Unity.Netcode.Transports.UNET;
 using Unity.Netcode.Transports.UTP;
 using UnityEngine;
 


### PR DESCRIPTION
Removed two "using" statements for the deprecated UNET, which were causing errors when importing the package.