### PR TITLE
Fix Unity.Collections not being referenced in assembly for Photon Realtime Transport

### DIFF
--- a/Transports/com.community.netcode.transport.photon-realtime/Runtime/com.community.netcode.transport.photon-realtime.asmdef
+++ b/Transports/com.community.netcode.transport.photon-realtime/Runtime/com.community.netcode.transport.photon-realtime.asmdef
@@ -2,7 +2,8 @@
     "name": "Photon Realtime Transport for Netcode for GameObjects",
     "rootNamespace": "Netcode.Transports.PhotonRealtime",
     "references": [
-        "Unity.Netcode.Runtime"
+        "Unity.Netcode.Runtime",
+        "Unity.Collections"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
This fixes #230.