### PR TITLE
Feature/web socket.connect returns bool instead of void

### DIFF
--- a/Transports/com.community.netcode.transport.websocket/Runtime/Libraries/websocket-sharp/websocket-sharp/WebSocket.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/Libraries/websocket-sharp/websocket-sharp/WebSocket.cs
@@ -3214,7 +3214,7 @@ namespace WebSocketSharp
     ///   A series of reconnecting has failed.
     ///   </para>
     /// </exception>
-    public void Connect ()
+    public bool Connect ()
     {
       if (!_client) {
         var msg = "This instance is not a client.";
@@ -3232,7 +3232,11 @@ namespace WebSocketSharp
       }
 
       if (connect ())
+      {
         open ();
+        return true;
+      }
+      return false;
     }
 
     /// <summary>

--- a/Transports/com.community.netcode.transport.websocket/Runtime/NativeWebSocketClient.cs
+++ b/Transports/com.community.netcode.transport.websocket/Runtime/NativeWebSocketClient.cs
@@ -53,7 +53,10 @@ namespace Netcode.Transports.WebSocket
 
             try
             {
-                Connection.Connect();
+                if(!Connection.Connect())
+                {
+                    throw InvalidOperationException($"Cannot connect to url {Connection.Url}");
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
When I was trying to use websocket to connect to server, I've noted that if I try to connect as client on an inexistant server, the code returned true and I was trying to do somme code with server whereas the connection was not realized.

I've determined that the function `Connect` in the `WebSocket` wlass of the WebSocket-Sharp library was returning void.
BUT, the inner function returned bool.

I've think to pass the bool up to the caller to have better control over the life cycle.