### PR TITLE
Fixed SteamClient initialization check + Fixed end region and missing method

### DIFF
--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -288,7 +288,7 @@ namespace Netcode.Transports.Facepunch
 
         #region Utility Methods
 
-		private IEnumerator InitSteamworks()
+		private System.Collections.IEnumerator InitSteamworks()
 		{
 		    yield return new WaitUntil(() => SteamClient.IsValid);
 		

--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -96,7 +96,8 @@ namespace Netcode.Transports.Facepunch
 
             try
             {
-                SteamClient.Init(steamAppId, false);
+				if (!SteamClient.IsValid)
+                	SteamClient.Init(steamAppId, false);
             }
             catch (Exception e)
             {

--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -286,6 +286,23 @@ namespace Netcode.Transports.Facepunch
 
         #endregion
 
-        #endregion
+        #region Utility Methods
+
+		private IEnumerator InitSteamworks()
+		{
+		    yield return new WaitUntil(() => SteamClient.IsValid);
+		
+		    SteamNetworkingUtils.InitRelayNetworkAccess();
+		
+		    if (LogLevel <= LogLevel.Developer)
+		        Debug.Log($"[{nameof(FacepunchTransport)}] - Initialized access to Steam Relay Network.");
+		
+		    userSteamId = SteamClient.SteamId;
+		
+		    if (LogLevel <= LogLevel.Developer)
+		        Debug.Log($"[{nameof(FacepunchTransport)}] - Fetched user Steam ID.");
+		}
+		
+		#endregion
     }
 }


### PR DESCRIPTION
SteamClient should only be initialised if needed otherwise duplicate initialisations will throw errors. This can happen if Steam is already initialised manually and then a facepunch transport connection is created, e.g. through StartHost.